### PR TITLE
Simplify spacing system

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,20 +1,13 @@
 import { useEffect, useRef, useState } from "react";
-import type { CSSProperties } from "react";
 import { useImagePreviewContext } from "./ImagePreviewProvider";
 
 type Props = {
   images: string[];
   columns?: number;
-  padding?: string | number;
   fullWidth?: boolean;
 };
 
-export default function Gallery({
-  images,
-  columns = 3,
-  padding,
-  fullWidth,
-}: Props) {
+export default function Gallery({ images, columns = 3, fullWidth }: Props) {
   // Intrinsic aspect ratios for each image (computed on load): width / height
   // Used to make each grid row have a uniform height that adapts to the widest
   // image in that row.
@@ -29,27 +22,10 @@ export default function Gallery({
         previewCtx.unregisterGallery(galleryIdRef.current);
     };
   }, [images, previewCtx]);
-  // On <lg screens, enforce 20px horizontal padding; on lg+ use the padding prop unless fullWidth.
-
-  type StyleWithVar = CSSProperties & { ["--gallery-padding"]?: string };
+  // On <lg screens, 20px horizontal padding; on lg+, 60px (consistent with markdown rhythm).
   if (images.length === 1) {
     return (
-      <div
-        className={
-          fullWidth ? "px-0" : "px-5 lg:[padding-inline:var(--gallery-padding)]"
-        }
-        style={
-          {
-            ...(fullWidth
-              ? {}
-              : {
-                  ["--gallery-padding"]:
-                    typeof padding === "number" ? `${padding}px` : padding,
-                }),
-            marginBottom: "var(--content-spacing, 1.5rem)",
-          } as StyleWithVar
-        }
-      >
+      <div className={`mb-5 lg:mb-15 ${fullWidth ? "px-0" : "px-5 lg:px-15"}`}>
         <img
           src={images[0]}
           className="w-full cursor-pointer"
@@ -62,23 +38,12 @@ export default function Gallery({
 
   return (
     <div
-      className={
+      className={`mb-5 lg:mb-15 ${
         fullWidth
           ? "grid gap-0.5 items-start px-0"
-          : "grid gap-0.5 items-start px-5 lg:[padding-inline:var(--gallery-padding)]"
-      }
-      style={
-        {
-          ...(fullWidth
-            ? {}
-            : {
-                ["--gallery-padding"]:
-                  typeof padding === "number" ? `${padding}px` : padding,
-              }),
-          gridTemplateColumns: `repeat(${columns}, 1fr)`,
-          marginBottom: "var(--content-spacing, 1.5rem)",
-        } as StyleWithVar
-      }
+          : "grid gap-0.5 items-start px-5 lg:px-15"
+      }`}
+      style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
     >
       {images.map((src, i) => {
         // Determine this tile's row boundaries based on the configured column count

--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -56,7 +56,6 @@ export default function ProjectModal({
     color: project.frontMatter.textColor,
     backgroundColor: project.frontMatter.backgroundColor,
     fontFamily: project.frontMatter.fontFamily,
-    "--content-spacing": project.frontMatter.padding,
   };
 
   return (
@@ -81,9 +80,7 @@ export default function ProjectModal({
             {...project.mdxSource}
             components={{
               ...mdxComponents,
-              Gallery: (props) => (
-                <Gallery padding={project.frontMatter.padding} {...props} />
-              ),
+              Gallery: (props) => <Gallery {...props} />,
             }}
           />
         </div>

--- a/src/content/202501/001.mdx
+++ b/src/content/202501/001.mdx
@@ -5,7 +5,6 @@ date: "2025-08-31"
 type: "gallery"
 textColor: "#e2e8f0"
 backgroundColor: "#040404"
-padding: "60px"
 basePath: "https://cadumillet-website-media.s3.sa-east-1.amazonaws.com/202501/001"
 ---
 

--- a/src/content/202501/002.mdx
+++ b/src/content/202501/002.mdx
@@ -5,7 +5,6 @@ date: "2025-08-31"
 type: "gallery"
 textColor: "#f2f2f2"
 backgroundColor: "#30423d"
-padding: "60px"
 basePath: "https://cadumillet-website-media.s3.sa-east-1.amazonaws.com/202501/002"
 ---
 

--- a/src/content/202502/001.mdx
+++ b/src/content/202502/001.mdx
@@ -5,7 +5,6 @@ date: "2025-09-10"
 type: "gallery"
 textColor: "#e2e8f0"
 backgroundColor: "#0b0b0b"
-padding: "60px"
 basePath: "https://cadumillet-website-media.s3.sa-east-1.amazonaws.com/202502/001"
 ---
 

--- a/src/content/202507/001.mdx
+++ b/src/content/202507/001.mdx
@@ -5,7 +5,6 @@ date: "2025-08-31"
 type: "gallery"
 textColor: "#e2e8f0"
 backgroundColor: "#040404"
-padding: "24px"
 basePath: "https://cadumillet-website-media.s3.sa-east-1.amazonaws.com/202507/001"
 ---
 

--- a/src/lib/mdx.ts
+++ b/src/lib/mdx.ts
@@ -26,7 +26,7 @@ export type FrontMatter = {
   type: string;
   textColor: string;
   backgroundColor: string;
-  padding: string;
+  padding?: string;
   basePath?: string;
   fontFamily?: string;
 };

--- a/src/pages/projects/[...slug].tsx
+++ b/src/pages/projects/[...slug].tsx
@@ -34,7 +34,6 @@ export default function ProjectPage({
     color: frontMatter.textColor,
     backgroundColor: frontMatter.backgroundColor,
     fontFamily: frontMatter.fontFamily,
-    "--content-spacing": frontMatter.padding,
   };
   return (
     <ImagePreviewProvider>
@@ -43,9 +42,7 @@ export default function ProjectPage({
           {...mdxSource}
           components={{
             ...mdxComponents,
-            Gallery: (props) => (
-              <Gallery padding={frontMatter.padding} {...props} />
-            ),
+            Gallery: (props) => <Gallery {...props} />,
           }}
         />
       </main>

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -3,10 +3,16 @@
 .markdown {
   line-height: 1.75;
   font-size: 1rem;
-  padding-bottom: var(--content-spacing, 1.5rem);
+  padding-bottom: 20px;
 }
 
-/* Global vertical rhythm using CSS variable set per-page */
+@media (min-width: 1024px) {
+  .markdown {
+    padding-bottom: 60px;
+  }
+}
+
+/* Global vertical rhythm */
 .markdown h1,
 .markdown h2,
 .markdown p,
@@ -16,7 +22,23 @@
 .markdown pre,
 .markdown code,
 .markdown hr {
-  margin-bottom: var(--content-spacing, 1.5rem);
+  /* for large screens we can rely on the container */
+  padding-inline: 20px;
+  margin-bottom: 20px;
+}
+
+@media (min-width: 1024px) {
+  .markdown h1,
+  .markdown h2,
+  .markdown p,
+  .markdown ul,
+  .markdown ol,
+  .markdown blockquote,
+  .markdown pre,
+  .markdown code,
+  .markdown hr {
+    margin-bottom: 60px;
+  }
 }
 
 /* Prevent double spacing by moving final spacing to the container */
@@ -36,6 +58,7 @@
 }
 
 .markdown h3 {
+  padding-inline: 20px;
   font-weight: 600;
 }
 


### PR DESCRIPTION
- **change readme**
- **feat(project-modal): add keyboard shortcuts and extract reusable hook Press F to toggle fullscreen (switches py-15 -> py-0 and max-w-7xl -> max-w-none w-full min-h-screen) Press Esc to close the modal Add src/hooks/useKeyboardShortcuts for reusable key handling Refactor ProjectModal to use the new hook with cleanup and preventDefault**
- **add command palette**
- **change command style**
- **feat(fonts): switch site to Geist; align Tailwind utilities**
- **add content**
- **set main grid imgs to 4:3 aspect ration and use tailwind container**
- **add loading state**
- **add navbar**
- **feat(ui): enforce mobile padding and fullscreen behaviors**
- **fix lint errors**
- **adjust spacing**
- **add content**
- **Simplify spacing system: use fixed 20px/60px, drop CSS vars and Gallery padding prop Replace --content-spacing with fixed spacing in CSS: 20px on small screens; 60px on lg+ via media query Apply 20px padding-inline to inline/code/hr and h3 on small screens Refactor Gallery spacing: Remove padding prop and inline style logic Use Tailwind utilities: px-5 lg:px-15 and mb-5 lg:mb-15 Keep fullWidth variant using px-0 Remove inline --content-spacing usage and stop passing padding to Gallery in: src/components/ProjectModal.tsx src/pages/projects/[...slug].tsx Affected files: src/styles/markdown.css src/components/Gallery.tsx src/components/ProjectModal.tsx src/pages/projects/[...slug].tsx**
